### PR TITLE
:bug: 修复小标签显示（表达）错误

### DIFF
--- a/lawDoc/views.py
+++ b/lawDoc/views.py
@@ -37,7 +37,7 @@ def index(request):
     allowed_count = 9999999999999
     # DEBUG 语句
 
-    request.session['allowed_count'] = 99999999999999999999999
+    request.session['allowed_count'] = allowed_count
     request.session['username'] = username
     request.session['identity'] = identity
 
@@ -48,7 +48,7 @@ def index(request):
     })
 
 
-#搜索结构体的构造
+# 搜索结构体的构造
 def buildSearchStruct(queryString):
     keyword = queryString.split('@')[0]
     if '@' in queryString:
@@ -139,16 +139,14 @@ def indexSearch(request):
         str = str + "@" + allSearchFieldListR[field]
         oneFieldnot.append(str)
 
-
-
     return render(
         request, "searchresult.html", {
             "LegalDocList": legalDocuments[0:length:],
             "countResults": countResults,
             "resultCount": resultCount,
             "searchStruct": searchStruct,
-            "onefield":oneField,
-            "onefieldnot":oneFieldnot,
+            "onefield": oneField,
+            "onefieldnot": oneFieldnot,
         })
 
 
@@ -279,7 +277,6 @@ def addSearch(request):
         str = str + "@" + allSearchFieldListR[field]
         oneFieldnot.append(str)
 
-
     return render(
         request, "result.html", {
             "LegalDocList": legalDocuments[0:length:],
@@ -289,10 +286,6 @@ def addSearch(request):
             "onefield": oneField,
             "onefieldnot": oneFieldnot,
         })
-
-
-
-
 
 
 @csrf_exempt
@@ -358,14 +351,15 @@ def groupBySearch(request):
         str = str + "@" + allSearchFieldListR[field]
         oneFieldnot.append(str)
 
-    return render(request, "result.html", {
-        "LegalDocList": legalDocuments,
-        "countResults": countResults,
-        "resultCount": resultCount,
-        "searchStruct": searchStruct,
-        "onefield": oneField,
-        "onefieldnot": oneFieldnot,
-    })
+    return render(
+        request, "result.html", {
+            "LegalDocList": legalDocuments,
+            "countResults": countResults,
+            "resultCount": resultCount,
+            "searchStruct": searchStruct,
+            "onefield": oneField,
+            "onefieldnot": oneFieldnot,
+        })
 
 
 @csrf_exempt
@@ -503,7 +497,6 @@ def allFieldNotSearch(searchStruct):
 
     allFieldNotKeyWordQuery = {"bool": {"must": allFieldNotKeyWordQuery}}
 
-
     return allFieldNotKeyWordQuery
 
 
@@ -530,7 +523,6 @@ def oneFieldSearch(searchStruct):
             oneFieldKeyWordMiniQuery = []
 
     oneFieldKeyWordQuery = {"bool": {"must": oneFieldKeyWordQuery}}
-
 
     return oneFieldKeyWordQuery
 
@@ -593,7 +585,6 @@ def fieldSearch(searchStruct):
 
     fieldKeyWordQuery = {"bool": {"must": fieldKeyWordQuery}}
 
-
     return fieldKeyWordQuery
 
 
@@ -655,7 +646,6 @@ def orderFieldSearch(searchStruct):
         }
 
     orderFieldKeyWordQuery = {"bool": {"must": orderFieldKeyWordQuery}}
-
 
     return orderFieldKeyWordQuery
 

--- a/lawDoc/views.py
+++ b/lawDoc/views.py
@@ -292,20 +292,43 @@ def addSearch(request):
 # 加载更多，java版本对应路径为getMore
 def getMore(request):
 
+    # 生成用于产生标签的语句
+    oneField = []
+    for field in searchStruct.oneFieldKeyWord.keys():
+        str = ""
+        for key in searchStruct.oneFieldKeyWord[field]:
+            str = str + " " + key
+        str = str + "@" + allSearchFieldListR[field]
+        oneField.append(str)
+
+    oneFieldnot = []
+    for field in searchStruct.oneFieldNotKeyWord.keys():
+        str = ""
+        for key in searchStruct.oneFieldNotKeyWord[field]:
+            str = str + " " + key
+        str = str + "@" + allSearchFieldListR[field]
+        oneFieldnot.append(str)
+
     pageId = int(request.POST.get('name'))
     if pageId * 20 < len(legalDocuments):
         return render(
             request, "result.html", {
                 "LegalDocList": legalDocuments[0:pageId * 20],
                 "countResults": countResults,
-                "resultCount": resultCount
+                "resultCount": resultCount,
+                "searchStruct": searchStruct,
+                "onefield": oneField,
+                "onefieldnot": oneFieldnot,
             })
     else:
         return render(
             request, "result.html", {
                 "LegalDocList": legalDocuments.index(0, len(legalDocuments)),
                 "countResults": countResults,
-                "resultCount": resultCount
+                "resultCount": resultCount,
+                "searchStruct": searchStruct,
+                "onefield": oneField,
+                "onefieldnot": oneFieldnot,
             })
 
         # paginator = Paginator(legalDocuments, 10)

--- a/templates/result.html
+++ b/templates/result.html
@@ -42,7 +42,11 @@
                             <button target="_blank"  action="searchlabel">
                                 <span></span>
                                 {%  for FieldKeyWord in searchStruct.FieldKeyWord %}
+                                {% if forloop.last %}
+                                {{ FieldKeyWord }}
+                                {% else %}
                                 {{ FieldKeyWord }}~
+                                {% endif %}
                                 {% endfor %}
                             （同域搜索）
                             </button>
@@ -60,9 +64,13 @@
                             <button target="_blank"  action="searchlabel">
                                 <span></span>
                                 {%  for OrderFieldKey in searchStruct.OrderFieldKey %}
+                                {% if forloop.last %}
+                                {{ OrderFieldKey }}
+                                {% else %}
                                 {{ OrderFieldKey }}>
+                                {% endif %}
                                  {% endfor %}
-                                (顺序搜索)
+                                （顺序搜索）
                             </button>
                         </div>
                     </form>

--- a/templates/searchresult.html
+++ b/templates/searchresult.html
@@ -119,7 +119,11 @@
                             <button target="_blank"  action="searchlabel">
                                 <span></span>
                                 {%  for FieldKeyWord in searchStruct.FieldKeyWord %}
+                                {% if forloop.last %}
+                                {{ FieldKeyWord }}
+                                {% else %}
                                 {{ FieldKeyWord }}~
+                                {% endif %}
                                 {% endfor %}
                             （同域搜索）
                             </button>
@@ -137,9 +141,13 @@
                             <button target="_blank"  action="searchlabel">
                                 <span></span>
                                 {%  for OrderFieldKey in searchStruct.OrderFieldKey %}
+                                {% if forloop.last %}
+                                {{ OrderFieldKey }}
+                                {% else %}
                                 {{ OrderFieldKey }}>
+                                {% endif %}
                                  {% endfor %}
-                                (顺序搜索)
+                                （顺序搜索）
                             </button>
                         </div>
                     </form>


### PR DESCRIPTION
#30 中 共同错误中的小标签表达错误

1. 把 同域搜索 和 顺序搜索 后多出现的 =~=, =>= 删除
2. 把 顺序搜索 中的半角括号 改为 全角括号